### PR TITLE
Implement Static Land module with ECMAScript module

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,29 @@ class MyType = {
 export {MyType}
 ```
 
+
+#### Example 3. Static Land module as ECMAScript modules
+
+```js
+// mytype.js
+
+// Static Land methods
+
+export function of(x) {
+  // ...
+}
+
+export function map(fn, value) {
+  // ...
+}
+```
+
+Import as
+
+```js
+import * as MyType from "./mytype" // MyType is now a Static Land module
+```
+
 ### Compatible libraries
 
 We have a list in the wiki. Feel free to add your library there.


### PR DESCRIPTION
Hello @rpominov. Thank you for the great work on this project.

This PR is half question half PR.

From reading the [module spec](https://github.com/rpominov/static-land/blob/master/docs/spec.md#module) it seems that we can implement a Static Land module simply as an ECMAScript module? I.e. where instead of exporting an object with the Static Land functions the ECMAScript module is itself the Static Land module. The code in the PR shows what I mean.

Is that a correct way to implement Static Land? Is that a good way to implement Static Land?